### PR TITLE
Change default port to 4040

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-RV_BACKEND_URL=http://localhost:8080
+RV_BACKEND_URL=http://localhost:4040
 AUTH_SECRET=unsafe_secret


### PR DESCRIPTION
In [tko-aly.localhost](https://github.com/TKOaly/tko-aly.localhost) port 8080 is used by traefik. Let's change the default port to 4040 so it doesn't clash with this in the local dev environment by default . RV could potentially be added to the localhost repo as well so this would be mandatory in that case.